### PR TITLE
David Radford's empirical impurity function

### DIFF
--- a/src/legend_detector_to_siggen.jl
+++ b/src/legend_detector_to_siggen.jl
@@ -185,7 +185,9 @@ function meta2siggen(meta::PropDict, env::Environment)
         # depth of full-charge-collection boundary for Li contact -> was removed from geometry because is not 
         # use manufacturer DL? in the future when our FCCD is in metadata, use that?
         # "Li_thickness" => 0,
-        "Li_thickness" => meta.characterization.manufacturer.dl_thickness_in_mm,
+        # QUICKFIX
+        # dl = vendor => take vendor; dl = number => take that; no dl => take 0
+        "Li_thickness" => env.dl == "vendor" ? meta.characterization.manufacturer.dl_thickness_in_mm : env.dl,
 
         # configuration for mjd_fieldgen (calculates electric fields & weighing potentials)
         # detector bias for fieldgen, in Volts

--- a/src/sim_config.jl
+++ b/src/sim_config.jl
@@ -52,9 +52,9 @@
 
     "Oprating voltage in V"
     operating_voltage::Real = 0
-
+    
     "Quickfix DL"
-    dl::Real = 0
+    dl::Union{Real,AbstractString} = 0
 end
 
 
@@ -62,27 +62,10 @@ end
 Simulation parameters related to the environment
 """
 function Environment(env_conf::PropDict)
-    dl =
-    if haskey(env_conf, :dl)
-        if env_conf.dl == "vendor"
-            dl_vendor = meta.characterization.manufacturer.dl_thickness_in_mm
-            if dl_vendor == nothing
-                @error "No DL provided by vendor!"
-            end
-            dl_vendor
-        else
-            env_conf.dl 
-        end
-    else
-        0
-    end
-
-    @info "DL = $(dl)mm"
-
     Environment(
         env_conf.medium,
         env_conf.crystal_temperature_in_K,
         haskey(env_conf, :operating_voltage_in_V) ? env_conf.operating_voltage_in_V : 0,
-        dl
+        haskey(env_conf, :dl) ? env_conf.dl : 0
     )
 end


### PR DESCRIPTION
Main development: implemented the function `a+b*z+c*exp((z-L)/tau)` for SSD impurity profile. Works better than quadratic fit. Now can also truly compare SSD and siggen.

Implemented in such a way that the fit happens in the crystal coordinates (0 = seed end), and the resulting coefficients are saved from that point of view. Then, the actual impurity density function substitutes `z` in the formula with `Z0 - z` where `Z0` is the offset of the detector Z=0 from seed end, and is saved in `legend-detectors` in the crystal jsons under `detector_offset_in_mm`.

Quickfix: introduced parameter DL into `Environment` - does not belong there, but needed a quick temporary hack to simulate with different DL to understand SSD behavior. Will remove later, or think of a better way to input such parameter in settings properly.